### PR TITLE
Allow usage with PHP 8.2 as that is supported with L12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/codedge/laravel-fpdf"
     },
     "require": {
-        "php": "~8.3 || ~8.4",
+        "php": "~8.2 || ~8.3 || ~8.4",
         "illuminate/support": "^11.0 || ^12.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is just a reminder PR to remind us why this repo was made. The original repo removed PHP8.2 support, even though L12 does support it. There are PR's in the original repo, but none of them are merged.

If one of them get's merged, or we do a jump to PHP 8.3, then this repo can be removed and we can continue to use the original repo.